### PR TITLE
Fix orderQuantity

### DIFF
--- a/src/main/webapp/assets/js/searchMenu.js
+++ b/src/main/webapp/assets/js/searchMenu.js
@@ -30,7 +30,6 @@ var ModalSearchMenu = function(modalContainer, orderName, orderQuantity, orderCo
 
 		self.idPlaceItem.val(id);
 		self.orderName.val(name);
-		self.orderQuantity.val(1);
 		self.orderCost.val(price);
 		self.btnEditIcon.text('mode_edit');
 		self.btnAdd.show();


### PR DESCRIPTION
searchMenu		:[-]Removed the "self.orderQuantity.val(1);" line, which was resenting the order quantity to 1 when adding a new item

Signed-off-by: Min Bo Zhong Zhu <Min Bo Zhong@jalasoft.local>